### PR TITLE
fix: fixing textarea min and max height

### DIFF
--- a/src/components/Organisms/CreateAnnouncementStep1.tsx
+++ b/src/components/Organisms/CreateAnnouncementStep1.tsx
@@ -21,7 +21,7 @@ const CreateAnnouncementStep1 = () => {
                     error={errors.title?.message} label="Adicione seu Título" errorMessage={errors.title?.message}/>
                 <div className="flex flex-col gap-3">
                     <Label children="Adicione a descrição do seu anúncio"/>
-                    <textarea className="h-[152px] max-w-[678px] sm:w-[500px] md:w-[600px] lg:w-[678px] rounded-md py-2 px-3 text-base outline-none focus:ring-2 focus:ring-primary placeholder-lighter-secondary" placeholder="Adicione  descrição do seu anúncio" 
+                    <textarea className="min-h-[100px] h-[152px]  max-h-[400px] max-w-[678px] sm:w-[500px] md:w-[600px] lg:w-[678px] rounded-md py-2 px-3 text-base outline-none focus:ring-2 focus:ring-primary placeholder-lighter-secondary" placeholder="Adicione  descrição do seu anúncio" 
                     {...register("description") }
                     />
                     {errors.description && <span className="text-red-500">{errors.description.message}</span>}


### PR DESCRIPTION
Motivação
 - A altura do textarea da tela de criar anúncios estava a critério do usuário causando quebra do layout, sendo necessário definir a altura mínima e máxima 

Proposta de solução

 - Ajeitar a altura mínima e altura máxima do textarea da tela  de criar anúncios

Testes:
Máximo:
![image](https://github.com/user-attachments/assets/cbbf5828-fb13-49b5-a51a-0ebef891dc91)
Mínimo:
![image](https://github.com/user-attachments/assets/e0ad917b-c399-4d20-878b-20c25fba126a)
