### PR TITLE
Integra autenticação com front, usando cookies, implementa login/out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@types/node": "^22.10.1",
         "@types/react": "^18.3.10",
         "@types/react-dom": "^18.3.0",
         "@types/react-input-mask": "^3.0.5",
@@ -35,6 +36,7 @@
         "eslint-plugin-react-refresh": "^0.4.12",
         "globals": "^15.9.0",
         "postcss": "^8.4.47",
+        "react-error-overlay": "6.0.9",
         "tailwindcss": "^3.4.13",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.7.0",
@@ -1494,6 +1496,16 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
@@ -3726,6 +3738,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-hook-form": {
       "version": "7.53.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
@@ -4328,6 +4347,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@types/node": "^22.10.1", 
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
     "@types/react-input-mask": "^3.0.5",

--- a/src/components/Molecules/ProfileSidebar.tsx
+++ b/src/components/Molecules/ProfileSidebar.tsx
@@ -3,13 +3,17 @@ import LinkItem from '../Atoms/LinkItem'
 import { FiLogOut } from 'react-icons/fi'
 
 const ProfileSidebar = () => {
+const logOut = () => {
+  document.cookie = "";
+}
+  
   return (
     <nav className='px-6 lg:px-14 bg-secondary pt-8 min-h-screen'>
         <ul className='flex flex-col gap-6 text-base lg:text-xl  items-center text-light font-semibold hover:*:-translate-y-1 [&>*]:transition-all [&>*]:ease-in-out gap-'>
             <NavLinkItem children="Meu Perfil" link="/meu-perfil" />
             <NavLinkItem children="Editar Perfil" link="/meu-perfil/editar" />
             <NavLinkItem children="Meus Chats" link="/meu-perfil/chats" />
-            <LinkItem to="/login" children="Logout" icon={<FiLogOut color="#FFFFFF" size={22} />}   />
+            <LinkItem onClick = {logOut} to="/login" children="Logout" icon={<FiLogOut color="#FFFFFF" size={22} />}   />
         </ul>
     </nav>
   )

--- a/src/components/Organisms/LoginForm.tsx
+++ b/src/components/Organisms/LoginForm.tsx
@@ -1,33 +1,57 @@
 import Button from "@/components/Atoms/Button";
-
+import axios from "axios";
 import React, { useState } from 'react'
 import {MouseEvent} from "react";
 const LoginForm =() => {
-
 const [CPF,setCPF] = useState('')
 const [password,setPassword] = useState('')
 const [CPFError,setCPFError] = useState('')
 const [passwordError,setPasswordError] = useState('')
 
+
+
 const onButtonClick = (event:MouseEvent) => {
     if('' == CPF){
         setCPFError("Insira seu CPF")
     }
-    else if(!((/^[0-9]{3,3}\.[0-9]{3,3}\.[0-9]{3,3}\-[0-9]{2,2}$/.test(CPF)) ||  (/^[0-9]{3,3}[0-9]{3,3}[0-9]{3,3}[0-9]{2,2}$/.test(CPF)))){
+    else if(!((/^[0-9]{3,3}\.[0-9]{3,3}\.[0-9]{3,3}\-[0-9]{2,2}$/.test(CPF)))){
         setCPFError("CPF inválido")
     }
-    else{
-        setCPFError('')
+    
+    if((password != '') && (CPF != '')){
+        
+        const url = 'https://dynamic-herring-cosmic.ngrok-free.app/api/v1/auth/sign_in';
+
+        const data = {
+          cpf: CPF,
+          password: password
+         
+        };
+
+            axios.post(url,data)
+                .then((response) => {
+                setCPFError("");
+                setPasswordError("");
+                const auth = {accessToken :response.headers['access-token'], client : response.headers['client'] , uid: response.headers['uid'] }
+                const CookieData = JSON.stringify(auth);
+                document.cookie = `auth=${CookieData}; path=/; expires=${new Date(Date.now() + 31536000).toUTCString()};`;
+                
+                window.location.href = '/';
+
+                })
+                .catch(error => {
+                  console.error(error);
+                  setPasswordError("Login e senha inválidos");
+                  console.log("login inválido");
+                });   
+                
+        
+
+
+            
     }
-    if('' == password){
-        setPasswordError("Insira sua senha")
-    }
-    else{
-        setPasswordError('')
-    }
-    if((CPFError == '') && (passwordError == '') && (password != '') && (CPF != '')){
-        window.location.href = '/'
-    }
+
+
 
 };
 

--- a/src/pages/AdPage.tsx
+++ b/src/pages/AdPage.tsx
@@ -108,7 +108,7 @@ return(
 
                         <div>   
                             <div className= "text-4xl text-right font-bold mt-2">{`R$${parseFloat(currentAd?.price!.toString()!).toFixed(2).toString()}`}</div>
-                            <div className="text-right mt-3"><Button text="Iniciar" className="px-5" /></div>
+                            <div className="text-right mt-3"><Button onClick = {() => {console.log(import.meta.env.VITE_UID)}} text="Iniciar" className="px-5" /></div>
                             <div className = "flex items-center text-center border border-secondary rounded-md w-96 h-40 ml-auto mt-10">
                             <div className = "bg-lighter-primary rounded-full w-28 h-28 mt-4 ml-4 " ></div>
                             <span className="grid grid-rows-2 w-64">

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import {RouteProps,} from 'react-router-dom';
+import axios from "axios";
+import LoginPage from "@/pages/LoginPage";
+import { useState } from 'react';
+import { access } from 'fs';
+
+
+
+
+
+const ProtectedRoute: React.FC<RouteProps> = ({element}:RouteProps) => {
+  const [auth,SetAuth] = useState(false)
+  const [loading, setLoading] = useState(true);
+  const Auth = () => {
+    const url = 'https://dynamic-herring-cosmic.ngrok-free.app/api/v1/auth/validate_token';
+    var authData = {accessToken: "" , uid: "", client: "" };
+    if (document.cookie != "") {
+      const cookieData = document.cookie.match(/auth=([^;]*)/)![1];
+      authData = JSON.parse(cookieData);
+  }
+
+    axios.get(url, {
+      headers: {
+        'access-token': authData.accessToken,
+        'uid' : authData.uid,
+        'client' : authData.client,
+        'ngrok-skip-browser-warning': '69420',
+      },
+          }).then((response) => {
+                  if(response.status == 200){
+                    SetAuth(true);
+                    setLoading(false);            
+                  }
+                  }).catch((error) => {
+                    SetAuth(false);
+                    setLoading(false);
+                  }) ;
+  }
+   
+  useEffect(() => {(async () => {await Auth()})();},[]); 
+  
+  if(loading){
+    return (<></>)
+  }
+  else if (!auth) {
+    return (<LoginPage/>)
+  } 
+  return (element)
+
+};
+
+export default ProtectedRoute;

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -11,23 +11,28 @@ import ProfileTemplate from "@/template/ProfileTemplate";
 import ProfileDisplay from "@/components/Organisms/ProfileDisplay";
 import ProfileEdition from "@/components/Organisms/ProfileEdition";
 import ProfileChats from "@/components/Organisms/ProfileChats";
+import ProtectedRoute from "./ProtectedRoute";
+
+
+
 const AppRoutes = () => {
+
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/" element={<LayoutTemplate />}>
-          <Route path="meu-perfil" element={<ProfileTemplate />}>
-            <Route index element={<ProfileDisplay />} />
-            <Route path="editar" element={<ProfileEdition />} />
-            <Route path="chats" element={<ProfileChats />} />
+        <Route path="/" element={<ProtectedRoute element = {<LayoutTemplate />}/>}>
+          <Route path="meu-perfil" element={<ProtectedRoute element = {<ProfileTemplate />}/>}>
+            <Route index element={<ProtectedRoute element = {<ProfileDisplay />}/>} />
+            <Route path="editar" element={<ProtectedRoute element = {<ProfileEdition />}/>} />
+            <Route path="chats" element={<ProtectedRoute element = {<ProfileChats />}/>} />
           </Route>
-          <Route index element={<Home />} />
-          <Route path="meus-anuncios" element={<MyAds />} />
-          <Route path="criar-anuncios" element={<CreateAnnouncementPage />} />
-          <Route path="anuncio/:adId" element={<AdPage />} />
+          <Route index element={<ProtectedRoute element = {<Home />}/>} />
+          <Route path="meus-anuncios" element={<ProtectedRoute element = {<MyAds />}/>} />
+          <Route path="criar-anuncios" element={<ProtectedRoute element = {<CreateAnnouncementPage />}/>} />
+          <Route path="anuncio/:adId" element={<ProtectedRoute element = {<AdPage />}/>} />
         </Route>
-        <Route path="/rating" element={<RatingModal />} />
+        <Route path="/rating" element={<ProtectedRoute element = {<RatingModal />}/>} />
       </Routes>
     </BrowserRouter>
   );

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "types": ["node"],
     "skipLibCheck": true,
     "allowJs": true,
     "paths":{


### PR DESCRIPTION

## Motivação

Possibilitar integração de outras funcionalidades obedecendo as regras de autenticação do back, com o envio de três cabeçalhos de autenticação: Uid, Client e Access-Token.

## Proposta de solução

Armazenar os valores retornados dos cabeçalhos na requisição de sign in nos cookies do navegador para depois acessá-los na requisição de validate_token que é realizada ao acessar uma rota protegida do site. Isso garante que cada página só vai ser acessada por alguém que esteja logado previamente.

## Links Importante

- Trello: [Integrar Autenticação no FrontEnd](https://trello.com/c/dv11rZut/25-integrar-autentica%C3%A7%C3%A3o-no-frontend)

## Observações

Para realizar outras requisições a fim de integração, basta acessar os cookies da forma como os mesmos são acessados para realizar a requisição validate_token em ProtectedRoute.tsx.